### PR TITLE
fix: TypeError exception for newest python versions

### DIFF
--- a/yapbol/pbo.py
+++ b/yapbol/pbo.py
@@ -46,11 +46,7 @@ def read_asciiz(f):
 
 
 def write_asciiz(f, string):
-    if isinstance(string, str):
-        f.write(string)  # Write directly
-    else:
-        f.write(string.encode('utf-8'))
-
+    f.write(six.ensure_binary(string))
     f.write(b'\0')
 
 


### PR DESCRIPTION
Issue: **TypeError: a bytes-like object is required, not 'str'**

Can be reproduced with Python 3.8+ (Tested on Python 3.8 and Python 3.11)

```python
from yapbol import PBOFile

pbo = PBOFile.read_file('filepath.pbo')
pbo.save_file('filepath.repack.pbo')
```
